### PR TITLE
Add KASLR for PIE ELF kernels when using stivale

### DIFF
--- a/STIVALE.md
+++ b/STIVALE.md
@@ -104,6 +104,8 @@ struct stivale_header {
                       // bit 1  0 = 4-level paging, 1 = use 5-level paging (if
                                                         available)
                                 Ignored if booting a 32-bit kernel.
+                      // bit 2  0 = Disable KASLR, 1 = enable KASLR (up to 1GB slide)
+                                Ignored if booting a 32-bit or non-relocatable kernel
                       // All other bits undefined.
 
     uint16_t framebuffer_width;   // These 3 values are parsed if a graphics mode

--- a/src/lib/elf.h
+++ b/src/lib/elf.h
@@ -6,8 +6,8 @@
 
 int elf_bits(struct file_handle *fd);
 
-int elf64_load(struct file_handle *fd, uint64_t *entry_point, uint64_t *top);
-int elf64_load_section(struct file_handle *fd, void *buffer, const char *name, size_t limit);
+int elf64_load(struct file_handle *fd, uint64_t *entry_point, uint64_t *top, uint64_t slide);
+int elf64_load_section(struct file_handle *fd, void *buffer, const char *name, size_t limit, uint64_t slide);
 
 int elf32_load(struct file_handle *fd, uint32_t *entry_point, uint32_t *top);
 int elf32_load_section(struct file_handle *fd, void *buffer, const char *name, size_t limit);

--- a/src/lib/random.c
+++ b/src/lib/random.c
@@ -1,0 +1,48 @@
+#include <lib/blib.h>
+
+int rdrand_available = 0;
+
+static void check_rdrand(void) {
+    uint32_t eax, ebx, ecx, edx;
+    int ret = cpuid(1, 0, &eax, &ebx, &ecx, &edx);
+    if (ret)
+        return;
+
+    if (ecx & (1 << 30))
+        rdrand_available = 1;
+}
+
+static void init_simple_rand(void) {
+    // TODO: Some fallback randomness init
+}
+
+void init_random(void) {
+    check_rdrand();
+    if (!rdrand_available) {
+        init_simple_rand();
+    }
+}
+
+static uint32_t rdrand(void) {
+    uint32_t val;
+
+    asm (
+        "1:rdrand %0\n\t"
+        "jnc 1b\n\t"
+        :"=r"(val)
+    );
+
+    return val;
+}
+
+static uint32_t simple_rand(void) {
+    // TODO: Some fallback randomness
+    return 0xFEEDFACE;
+}
+
+uint32_t get_random(void) {
+    if (rdrand_available)
+        return rdrand();
+    else
+        return simple_rand();
+}

--- a/src/lib/random.h
+++ b/src/lib/random.h
@@ -1,0 +1,10 @@
+#ifndef __LIB__RANDOM_H__
+#define __LIB__RANDOM_H__
+
+#include <stdint.h>
+
+void init_random(void);
+
+uint32_t get_random(void);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ asm (
 #include <lib/config.h>
 #include <lib/e820.h>
 #include <lib/print.h>
+#include <lib/random.h>
 #include <fs/file.h>
 #include <lib/elf.h>
 #include <protos/stivale.h>
@@ -98,6 +99,7 @@ refresh:
 void main(int boot_drive) {
     // Initial prompt.
     init_vga_textmode();
+    init_random();
 
     print("qloader2\n\n");
 


### PR DESCRIPTION
For now, only the `RELA` segments with relocations of type `R_X86_64_RELATIVE` are supported. This is the most common relocation though, for example, my kernel is over 1000 relocations and only use this one type of relocation. If another relocation type is desired, it should be easy to add.

Loading with a slide of e.g. 650MB causes the kernel to load at that offset in physical memory too. 
I'll leave this as something to be fixed when there at least is a simple vmm, as it would be a little bit of a pain to do the currently desired memory layout in the existing page tables.

