### PR TITLE
Mark the partition as bootable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and install qloader2, one can do:
 dd if=/dev/zero bs=1M count=0 seek=64 of=test.img
 parted -s test.img mklabel msdos
 parted -s test.img mkpart primary 1 100%
-parted -s loader.img set 1 boot on
+parted -s test.img set 1 boot on
 
 echfs-utils -m -p0 test.img quick-format 32768
 echfs-utils -m -p0 test.img import path/to/qloader2.cfg qloader2.cfg

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and install qloader2, one can do:
 dd if=/dev/zero bs=1M count=0 seek=64 of=test.img
 parted -s test.img mklabel msdos
 parted -s test.img mkpart primary 1 100%
-parted -s test.img set 1 boot on
+parted -s test.img set 1 boot on # Workaround for buggy BIOSes
 
 echfs-utils -m -p0 test.img quick-format 32768
 echfs-utils -m -p0 test.img import path/to/qloader2.cfg qloader2.cfg

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ and install qloader2, one can do:
 dd if=/dev/zero bs=1M count=0 seek=64 of=test.img
 parted -s test.img mklabel msdos
 parted -s test.img mkpart primary 1 100%
+parted -s loader.img set 1 boot on
+
 echfs-utils -m -p0 test.img quick-format 32768
 echfs-utils -m -p0 test.img import path/to/qloader2.cfg qloader2.cfg
 echfs-utils -m -p0 test.img import path/to/kernel.elf kernel.elf


### PR DESCRIPTION
Some BIOSes (eg. my laptop's) require at least one partition to be marked as bootable, this patch can save one from frustration.