### PR TITLE
Force IPV4 in toolchain script

### DIFF
--- a/toolchain/make_toolchain.sh
+++ b/toolchain/make_toolchain.sh
@@ -28,7 +28,7 @@ mkdir -p build
 cd build
 
 if [ ! -f binutils-$BINUTILSVERSION.tar.gz ]; then
-    wget -4 https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.gz
+    wget -4 https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.gz # Force IPv4 otherwise wget hangs
 fi
 if [ ! -f gcc-$GCCVERSION.tar.gz ]; then
     wget -4 https://ftp.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.gz

--- a/toolchain/make_toolchain.sh
+++ b/toolchain/make_toolchain.sh
@@ -31,7 +31,7 @@ if [ ! -f binutils-$BINUTILSVERSION.tar.gz ]; then
     wget -4 https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.gz # Force IPv4 otherwise wget hangs
 fi
 if [ ! -f gcc-$GCCVERSION.tar.gz ]; then
-    wget -4 https://ftp.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.gz
+    wget -4 https://ftp.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.gz # Same as above
 fi
 
 tar -xf binutils-$BINUTILSVERSION.tar.gz

--- a/toolchain/make_toolchain.sh
+++ b/toolchain/make_toolchain.sh
@@ -28,10 +28,10 @@ mkdir -p build
 cd build
 
 if [ ! -f binutils-$BINUTILSVERSION.tar.gz ]; then
-    wget https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.gz
+    wget -4 https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.gz
 fi
 if [ ! -f gcc-$GCCVERSION.tar.gz ]; then
-    wget https://ftp.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.gz
+    wget -4 https://ftp.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.gz
 fi
 
 tar -xf binutils-$BINUTILSVERSION.tar.gz


### PR DESCRIPTION
I was gonna build a toolchain for qloader2 and wget simply hanged. This patch fixes it.